### PR TITLE
feat: implement sign-in and sign-up pages with authentication logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "15.3.4",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-router-dom": "^7.6.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -2228,6 +2229,14 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4781,6 +4790,42 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
+    "node_modules/react-router": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.3.tgz",
+      "integrity": "sha512-zf45LZp5skDC6I3jDLXQUu0u26jtuP4lEGbc7BbdyxenBN1vJSTA18czM2D+h5qyMBuMrD+9uB+mU37HIoKGRA==",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.3.tgz",
+      "integrity": "sha512-DiWJm9qdUAmiJrVWaeJdu4TKu13+iB/8IEi0EW/XgaHCjW/vWGrwzup0GVvaMteuZjKnh5bEvJP/K0MDnzawHw==",
+      "dependencies": {
+        "react-router": "7.6.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -4962,6 +5007,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -9,19 +9,20 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "next": "15.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.3.4"
+    "react-router-dom": "^7.6.3"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.3.4",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/src/pages/[user_id]/chat/[chat_id].tsx
+++ b/src/pages/[user_id]/chat/[chat_id].tsx
@@ -1,14 +1,21 @@
-// src/pages/[user_id]/chat/[chat_id].tsx
-
 import { useRouter } from 'next/router';
-import React from 'react';
-import { useEffect } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
+
+type Message = {
+  sender: 'user' | 'assistant';
+  text: string;
+};
+
+
 
 export default function ChatPage() {
   const router = useRouter();
   const { user_id, chat_id } = router.query;
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const [error , setError] = useState('')
+  const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  // Auth check
   useEffect(() => {
     const token = localStorage.getItem('token');
     if (!token) {
@@ -16,12 +23,147 @@ export default function ChatPage() {
     }
   }, [router]);
 
+  // 自動スクロール
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+
+  // Fetch all messages for a chat
+  useEffect(() => {
+  if (!user_id || !chat_id) return;
+  const fetchMessages = async () => {
+    try {
+      const response = await fetch(`http://localhost:8000/${user_id}/chat/${chat_id}/message`);
+      if (!response.ok) {
+        setError("Failed to fetch messages");
+        return;
+      }
+      const data = await response.json();
+      // Map backend messages to frontend format
+      const mapped: Message[] = Array.isArray(data)
+        ? data.map((msg: any) => ({
+            sender: msg.role === 'user' ? 'user' : 'assistant',
+            text: msg.content
+          }))
+        : [];
+      setMessages(mapped);
+    } catch (error) {
+      setError("An error occurred while fetching messages.");
+    }
+  };
+  fetchMessages();
+}, [user_id, chat_id]);
+
+  // add new message when the button is clicked
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+
+    const currentInput = input;
+    setInput('');
+
+    try {
+      const response = await fetch(`http://localhost:8000/${user_id}/chat/${chat_id}/message`, {
+        method: "POST",
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          chatId: chat_id,
+          userId: user_id,
+          content: currentInput,
+          chatname: "Default Chat", // or use a variable if you have chat names
+          role: "user"
+        })
+      });
+      if(!response.ok) {
+        const errorData = await response.json();
+        setError(errorData.detail || "An error occurred during chat.");
+        return;
+      }
+      const data = await response.json();
+      console.log(data);
+
+      if (!data.user || !data.assistant) {
+        setError('Invalid response from server.');
+        return;
+      }
+
+      setMessages((prev) => [
+        ...prev,
+          { sender: 'user', text: currentInput },
+          { sender: 'assistant', text: data.assistant.content }
+      ]);
+    } catch(error){
+      if(error instanceof Error) {
+        setError(error.message);
+      } else {
+        setError('An unknown error occurred.');
+      }
+      console.log("error: ", error)
+    }
+  };
+
+  console.log("messages:", messages);
+
+
   return (
-    <div className="p-6">
-      <h1 className="text-xl font-bold">Chat Page</h1>
-      <p className="mt-2">User ID: {user_id}</p>
-      <p className="mt-2">Chat ID: {chat_id}</p>
-      {/* 実際のチャット画面のコンポーネントをここに組み込む */}
+    <div className="flex flex-col h-screen bg-neutral-900 text-white">
+      {/* チャット表示エリア */}
+      <div className="flex justify-center w-full overflow-y-auto px-6 py-4">
+        <div className="w-full max-w-3xl space-y-10"> {/* ← 画面中央60% */}
+          {messages.map((msg, idx) => {
+            const isUser = msg.sender === 'user';
+            const nextMsg = messages[idx + 1];
+            const isLast = idx === messages.length - 1;
+            const isNextDifferent = !isLast && nextMsg.sender !== msg.sender;
+
+            return (
+              <React.Fragment key={idx}>
+                <div className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>
+                  {isUser ? (
+                    <div className="bg-neutral-700 text-white px-6 py-3 rounded-xl max-w-[60%]">
+                      {msg.text}
+                    </div>
+                  ) : (
+                    <div className="text-white px-6 py-3 rounded-xl max-w-[70%]">
+                      {msg.text}
+                    </div>
+                  )}
+                </div>
+
+                {/* 区切り線（やりとりごと） */}
+                {isNextDifferent && (
+                  <div className="border-t border-neutral-600 opacity-40 my-10" />
+                )}
+              </React.Fragment>
+            );
+          })}
+          <div ref={messagesEndRef} />
+        </div>
+      </div>
+
+
+      {/* 入力フォーム */}
+      <form
+        onSubmit={handleSubmit}
+        className="h-[10vh] px-6 py-3 flex items-center justify-center gap-3 mb-8"
+      >
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          className="w-[50%] h-16 bg-neutral-700 text-white px-4 py-3 rounded-2xl outline-none"
+          placeholder="メッセージを入力..."
+        />
+        <button
+          type="submit"
+          className="bg-neutral-600 hover:bg-neutral-500 text-white px-4 py-2 rounded-md"
+        >
+          ask
+        </button>
+      </form>
     </div>
   );
 }

--- a/src/pages/[user_id]/chat/[chat_id].tsx
+++ b/src/pages/[user_id]/chat/[chat_id].tsx
@@ -1,0 +1,27 @@
+// src/pages/[user_id]/chat/[chat_id].tsx
+
+import { useRouter } from 'next/router';
+import React from 'react';
+import { useEffect } from 'react';
+
+export default function ChatPage() {
+  const router = useRouter();
+  const { user_id, chat_id } = router.query;
+
+  // Auth check
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      router.push('/signin');
+    }
+  }, [router]);
+
+  return (
+    <div className="p-6">
+      <h1 className="text-xl font-bold">Chat Page</h1>
+      <p className="mt-2">User ID: {user_id}</p>
+      <p className="mt-2">Chat ID: {chat_id}</p>
+      {/* 実際のチャット画面のコンポーネントをここに組み込む */}
+    </div>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,115 +1,16 @@
 import Image from "next/image";
 import { Geist, Geist_Mono } from "next/font/google";
+import SignIn from "@/pages/signin";
+import { useEffect } from "react";
+import { useRouter } from "next/router";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export default function Home() {
-  return (
-    <div
-      className={`${geistSans.className} ${geistMono.className} grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]`}
-    >
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-              src/pages/index.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=default-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=default-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=default-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=default-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=default-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
-  );
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace("/signin"); // /signin にリダイレクト
+  }, [router]);
+
+  return null; // 何も表示しない
 }

--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import Link from "next/link";
+import { useState } from "react";
+import { useRouter } from "next/router";
+
+const SignIn: React.FC = () => {
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
+    const [error, setError] = useState('');
+    const router = useRouter();
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setError('');
+
+        const formBody = new URLSearchParams();
+        formBody.append('username', email);   // OAuth2PasswordRequestFormではusernameにメールを入れる仕様
+        formBody.append('password', password);
+
+        try {
+            const response = await fetch('http://localhost:8000/login', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
+                body: formBody.toString()
+            });
+            if(!response.ok) {
+                const errorData = await response.json();
+                setError(errorData.detail || "An error occurred during sign in.");
+                return;
+            }
+            const data = await response.json();
+            console.log("Login response data:", data);
+            localStorage.setItem('token', data.access_token);
+            alert('Sign in successful!');
+            setTimeout(() => {
+                router.push(`/${data.user_id}/chat/${data.chat_id}`);
+            }, 1000);
+        } catch (err) {
+            if (err instanceof Error) {
+                setError(err.message);
+            } else {
+                setError('An unknown error occurred.');
+            }
+        }
+
+    }
+  
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-100">
+      <div className="bg-white p-8 rounded-lg shadow-md w-full max-w-sm">
+        <h2 className="text-2xl font-bold text-gray-900 mb-6 text-center">Sign In</h2>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
+        <form onSubmit={handleSubmit}>
+          <div className="mb-4">
+            <label className="block text-sm font-semibold text-gray-800 mb-2" htmlFor="email">
+              Email
+            </label>
+            <input
+              type="email"
+              id="email"
+              placeholder="Email"
+              className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+          <div className="mb-6">
+            <label className="block text-sm font-semibold text-gray-800 mb-2" htmlFor="password">
+              Password
+            </label>
+            <input
+              type="password"
+              id="password"
+              placeholder="Password"
+              className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
+          <button
+            type="submit"
+            className="w-full bg-black text-white py-2 rounded shadow-md hover:shadow-lg hover:bg-gray-800 active:scale-95 transition-all duration-200 ease-in-out"
+          >
+            Sign In
+          </button>
+        </form>
+        <div>
+          <div>
+            <p className="mt-4 text-sm text-gray-600 text-center">
+              Don't have an account?{" "}
+              <Link href="/signup" className="text-gray-500 hover:text-gray-900 hover:underline transition-colors duration-200">
+                Sign Up
+              </Link>
+            </p>
+          </div>
+          <div>
+            <p className="mt-2 text-sm text-gray-600 text-center">
+              <Link href="/forgot-password" className="text-gray-500 hover:text-gray-900 hover:underline transition-colors duration-200">
+                Forgot Password?
+              </Link>
+            </p>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  );
+};
+
+export default SignIn;

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+const SignUp: React.FC = () => {
+    return (
+        <div className="flex items-center justify-center min-h-screen bg-gray-100">
+            <div className="bg-white p-8 rounded-lg shadow-md w-full max-w-sm">
+                <h2 className="text-2xl font-bold text-gray-900 mb-6 text-center">Sign up</h2>
+                <form>
+                    <div className="mb-4">
+                        <label className="block text-sm font-semibold text-gray-800 mb-2" htmlFor="email">
+                        Email
+                        </label>
+                        <input
+                        type="email"
+                        id="email"
+                        placeholder="Email"
+                        className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900"
+                        required
+                        />
+                    </div>
+                    <div className="mb-6">
+                        <label className="block text-sm font-semibold text-gray-800 mb-2" htmlFor="password">
+                        Password
+                        </label>
+                        <input
+                        type="password"
+                        id="password"
+                        placeholder="Password"
+                        className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900"
+                        required
+                        />
+                    </div>
+                    <button
+                        type="submit"
+                        className="w-full bg-black text-white py-2 rounded shadow-md hover:shadow-lg hover:bg-gray-800 active:scale-95 transition-all duration-200 ease-in-out"
+                    >
+                        Sign Up
+                    </button>
+                </form>
+            </div>
+    </div>
+
+    )
+};
+
+export default SignUp;

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -1,11 +1,60 @@
 import React from "react";
+import { useState } from "react";
+import { useRouter } from "next/router";
 
 const SignUp: React.FC = () => {
+        const [email, setEmail] = useState('');
+        const [password, setPassword] = useState('');
+        const [error, setError] = useState('');
+        const router = useRouter();
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setError("");
+
+        const formBody = new URLSearchParams();
+        formBody.append('username', email);   // OAuth2PasswordRequestFormではusernameにメールを入れる仕様
+        formBody.append('password', password);
+
+        try {
+            const response = await fetch('http://localhost:8000/register', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    username: email,
+                    email,
+                    password
+                })
+            });
+            if(!response.ok) {
+                const errorData = await response.json();
+                setError(errorData.detail || "An error occurred during sign up.");
+                return;
+            }
+            const data = await response.json();
+            console.log("Sign up response data:", data);
+            localStorage.setItem('token', data.access_token);
+            alert('Sign up successful!');
+            setTimeout(() => {
+                router.push(`/signin`);
+            }, 1000);
+        } catch (err) {
+            if (err instanceof Error) {
+                setError(err.message);
+            } else {
+                setError('An unknown error occurred.');
+            }
+        }
+    }
+
     return (
         <div className="flex items-center justify-center min-h-screen bg-gray-100">
             <div className="bg-white p-8 rounded-lg shadow-md w-full max-w-sm">
                 <h2 className="text-2xl font-bold text-gray-900 mb-6 text-center">Sign up</h2>
-                <form>
+                {error && <p style={{ color: 'red' }}>{error}</p>}
+                <form onSubmit={handleSubmit}>
                     <div className="mb-4">
                         <label className="block text-sm font-semibold text-gray-800 mb-2" htmlFor="email">
                         Email
@@ -15,6 +64,8 @@ const SignUp: React.FC = () => {
                         id="email"
                         placeholder="Email"
                         className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
                         required
                         />
                     </div>
@@ -27,6 +78,8 @@ const SignUp: React.FC = () => {
                         id="password"
                         placeholder="Password"
                         className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
                         required
                         />
                     </div>


### PR DESCRIPTION
### Summary
- router setting
- login UI 
- sign-up UI 
- When clicked the sign-up button it jumps to the sign-up router
- connect sign-in feature to the login api endpoint
- When login is succefullt done, the back end return user_id and new chat_id and goes to the corresponding router
- add chat router and every chat created in the future will made in a way that the file that I made here(Now it just renders the corresponding user_id and chat_id)

### Other
- I think I'll modify the path because using id for the path maked it a bit complicated and it just doesn't look good 